### PR TITLE
grabbing module base through pssession rather than cimsession

### DIFF
--- a/helpers/prerequisites.psm1
+++ b/helpers/prerequisites.psm1
@@ -119,7 +119,8 @@ Function Test-NetStackPrerequisites {
                     else { ($TargetInfo | Where-Object Name -eq $thisTarget).Module = $false }
 
                     if ($EnableFirewallRules) {
-                        $ModuleBase = (Get-Module Test-NetStack -CimSession $thisTarget -ListAvailable | Select-Object -First 1).ModuleBase
+                        $psSession = New-PSSession -ComputerName $thisTarget
+                        $ModuleBase = (Get-Module Test-NetStack -PSSession $psSession -ListAvailable).ModuleBase
                         $null = New-NetFirewallRule -CimSession $thisTarget -DisplayName 'Test-NetStack - CTSTraffic' -Direction Inbound -Program "$ModuleBase\tools\CTS-Traffic\ctsTraffic.exe" -Action Allow -ErrorAction SilentlyContinue
                     }
                 }

--- a/helpers/prerequisites.psm1
+++ b/helpers/prerequisites.psm1
@@ -121,6 +121,7 @@ Function Test-NetStackPrerequisites {
                     if ($EnableFirewallRules) {
                         $psSession = New-PSSession -ComputerName $thisTarget
                         $ModuleBase = (Get-Module Test-NetStack -PSSession $psSession -ListAvailable).ModuleBase
+                        Remove-PSSession -Session $psSession
                         $null = New-NetFirewallRule -CimSession $thisTarget -DisplayName 'Test-NetStack - CTSTraffic' -Direction Inbound -Program "$ModuleBase\tools\CTS-Traffic\ctsTraffic.exe" -Action Allow -ErrorAction SilentlyContinue
                     }
                 }


### PR DESCRIPTION
$ModuleBase was blank when setting remote CTSTraffic firewall rules, so changed it to grab the module base through a PSSession as in the Get-Module docs