### PR TITLE
Warn only on no jitter collected

### DIFF
--- a/Test-NetStack.psm1
+++ b/Test-NetStack.psm1
@@ -391,8 +391,17 @@ Function Test-NetStack {
                             $Jitter  = Get-Jitter  -RoundTripTime ($thisSourceResult -ne -1)
 
                             $Result | Add-Member -MemberType NoteProperty -Name Latency -Value $Latency
-                            $Result | Add-Member -MemberType NoteProperty -Name Jitter -Value $Jitter
+                            $Result | Add-Member -MemberType NoteProperty -Name Jitter -Value $
+                            
+                            # Pass or fail Stage 1 based on connectivity
+                            if ($Result.Connectivity -eq $true) {
+                                $Result | Add-Member -MemberType NoteProperty -Name PathStatus -Value 'Pass'
+                            } 
+                            else {
+                                $Result | Add-Member -MemberType NoteProperty -Name PathStatus -Value 'Fail'
+                            }
 
+                            # Evaluate reliability results if collected
                             if ($TotalSent -and $SuccessPercentage -and $Latency -and $Jitter -and
                                 $Definitions.Reliability.ICMPSent  -and $Definitions.Reliability.ICMPReliability  -and
                                 $Definitions.Reliability.ICMPLatency -and $Definitions.Reliability.ICMPJitter) {
@@ -402,12 +411,12 @@ Function Test-NetStack {
                                         $Latency           -le $Definitions.Reliability.ICMPLatency     -and
                                         $Jitter            -le $Definitions.Reliability.ICMPJitter ) {
 
-                                        $Result | Add-Member -MemberType NoteProperty -Name PathStatus -Value 'Pass'
+                                        $Result | Add-Member -MemberType NoteProperty -Name ReliabilityStatus -Value 'Pass'
                                     }
-                                    else { $Result | Add-Member -MemberType NoteProperty -Name PathStatus -Value 'Fail' }
+                                    else { $Result | Add-Member -MemberType NoteProperty -Name ReliabilityStatus -Value 'Fail' }
                             }
                             else {
-                                $Result | Add-Member -MemberType NoteProperty -Name PathStatus -Value 'Fail'
+                                $Result | Add-Member -MemberType NoteProperty -Name ReliabilityStatus -Value 'Fail'
                                 "ERROR: Data failed to be collected for path ($($thisComputerName)) $($thisSource.IPAddress) -> $($thisTarget.IPAddress)" | Out-File $LogFile -Append -Encoding utf8 -Width 2000
                             }
 

--- a/Test-NetStack.psm1
+++ b/Test-NetStack.psm1
@@ -391,7 +391,7 @@ Function Test-NetStack {
                             $Jitter  = Get-Jitter  -RoundTripTime ($thisSourceResult -ne -1)
 
                             $Result | Add-Member -MemberType NoteProperty -Name Latency -Value $Latency
-                            $Result | Add-Member -MemberType NoteProperty -Name Jitter -Value $
+                            $Result | Add-Member -MemberType NoteProperty -Name Jitter -Value $Jitter
                             
                             # Pass or fail Stage 1 based on connectivity
                             if ($Result.Connectivity -eq $true) {


### PR DESCRIPTION
Almost all of the Stage 1 failures we see in the lab are due to jitter failing to be collected. We see that connectivity is marked "true" from the first run of Invoke-ICMPPMTUD, but it seems that no jitter value indicates the second run of Invoke-ICMPPMTUD failed to make a connection. I have not been able to repro this manually, so as discussed with Mark my solution for now is to mark Stage 1 as pass/fail based on connectivity, and evaluate the additional reliability stats in a non-blocking way.